### PR TITLE
fix(ci): force include date-fns to bypass broken default import

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "@typescript-eslint/eslint-plugin": "4.1.0",
     "@typescript-eslint/parser": "4.1.0",
     "@zerollup/ts-transform-paths": "^1.7.18",
+    "date-fns": "^2.16.1",
     "eslint": "^7.8.1",
     "eslint-config-prettier": "^6.11.0",
     "eslint-import-resolver-typescript": "^2.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2142,7 +2142,7 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
-date-fns@^2.0.1:
+date-fns@^2.0.1, date-fns@^2.16.1:
   version "2.16.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.16.1.tgz#05775792c3f3331da812af253e1a935851d3834b"
   integrity sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ==


### PR DESCRIPTION
This is a workaround to fix a broken `date-fns` import, that is being hoisted by `concurrently`. We're treeshake-including `concurrently` from our `devDependencies`, but it uses `require` instead of `import`, causing Webpack to not grab the default export of `date-fns/format`.